### PR TITLE
Pass channel as str instead of list.

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -42,8 +42,8 @@ class CharmDiscoveryserverCharm(CharmBase):
         """
         try:
             discovery_server = snap.add(
-                snap_names=['discoveryserver'],
-                channel=['latest/edge'],
+                snap_names='discoveryserver',
+                channel='latest/edge',
             )
             logger.debug('Successfully install discoveryserver')
         except snap.SnapError as e:


### PR DESCRIPTION
The function snap.add() expects a string for the channel argument and not a list.