### PR TITLE
Set discoveryserver public ip address

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -3,8 +3,11 @@
 type: "charm"
 bases:
   - build-on:
-    - name: "ubuntu"
-      channel: "20.04"
+      - name: ubuntu
+        channel: "20.04"
+        architectures:
+          - amd64
     run-on:
-    - name: "ubuntu"
-      channel: "20.04"
+      - name: ubuntu
+        channel: "20.04"
+        architectures: [amd64, s390x, ppc64el, arm64]

--- a/src/charm.py
+++ b/src/charm.py
@@ -58,6 +58,7 @@ class CharmDiscoveryserverCharm(CharmBase):
 
         # Learn more about statuses in the SDK docs:
         # https://juju.is/docs/sdk/constructs#heading--statuses
+        self.unit.open_port('tcp', 8087)
         self.unit.status = ActiveStatus()
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -13,6 +13,7 @@ develop a new k8s charm using the Operator Framework:
 """
 
 import logging
+import subprocess
 
 from ops.charm import CharmBase
 from ops.framework import StoredState
@@ -45,10 +46,16 @@ class CharmDiscoveryserverCharm(CharmBase):
                 snap_names='discoveryserver',
                 channel='latest/edge',
             )
-            logger.debug('Successfully install discoveryserver')
+            logger.info('Successfully install discoveryserver')
+            ingress_address = subprocess.check_output(['unit-get',
+                                                       'public-address'])
+            ingress_address = ingress_address.decode('utf-8').strip()
+            logger.info('Setting discovery.host=%s', ingress_address)
+            discovery_server.set({'discovery.host': ingress_address})
         except snap.SnapError as e:
             logger.exception('Error occurred installing discoveryserver snap.')
-            raise
+            raise e
+
         # Learn more about statuses in the SDK docs:
         # https://juju.is/docs/sdk/constructs#heading--statuses
         self.unit.status = ActiveStatus()


### PR DESCRIPTION
The discoveryserver will reply to requests including the host's ip
address when passed via the command line argument, this configures the
snap with the unit's public-address

Depends-On: https://github.com/openstack-charmers/snap-discoveryserver/pull/2
